### PR TITLE
handle the case where no scenario is matched by the validator

### DIFF
--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
@@ -148,7 +148,8 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
     var exchangedDocumentContext = billingObjectFactory.createExchangedDocumentContextType();
     var guideline = billingObjectFactory.createDocumentContextParameterType();
     var guidelineId =
-        createIdType("urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2#conformant#urn:xoev-de:kosit:extension:xrechnung_2.2");
+        createIdType(
+            "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2#conformant#urn:xoev-de:kosit:extension:xrechnung_2.2");
     guideline.setID(guidelineId);
     exchangedDocumentContext.getGuidelineSpecifiedDocumentContextParameter().add(guideline);
     return exchangedDocumentContext;
@@ -200,8 +201,7 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
 
     var tradeProduct = billingObjectFactory.createTradeProductType();
     tradeProduct.setGlobalID(createIdType(digaInvoice.getDigavEid(), "XR01"));
-    tradeProduct.setBuyerAssignedID(
-        createIdType(digaInvoice.getValidatedDigaCode(), "XR02"));
+    tradeProduct.setBuyerAssignedID(createIdType(digaInvoice.getValidatedDigaCode(), "XR02"));
     tradeProduct.getName().add(createTextType(digaInformation.getDigaName()));
     tradeProduct.setDescription(
         createTextType(
@@ -385,13 +385,14 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
         .getDuePayableAmount()
         .add(createAmountType(grandTotal));
     applicableHeaderTradeSettlement.setPayeeTradeParty(
-            createTradeParty(
-                    DigaTradeParty.builder()
-                            .companyId(
-                                    DigaUtils.ikNumberWithPrefix(digaInformation.getManufacturingCompanyIk()))
-                            .companyIk(digaInformation.getManufacturingCompanyIk())
-                            .companyName(digaInformation.getManufacturingCompanyName())
-                            .build())); // creditor - this needs to be the IK of the entity that sends the invoice
+        createTradeParty(
+            DigaTradeParty.builder()
+                .companyId(
+                    DigaUtils.ikNumberWithPrefix(digaInformation.getManufacturingCompanyIk()))
+                .companyIk(digaInformation.getManufacturingCompanyIk())
+                .companyName(digaInformation.getManufacturingCompanyName())
+                .build())); // creditor - this needs to be the IK of the entity that sends the
+    // invoice
     applicableHeaderTradeSettlement.setInvoiceCurrencyCode(
         createCurrencyCodeType(digaInvoice.getInvoiceCurrencyCode()));
     applicableHeaderTradeSettlement

--- a/src/main/java/com/alextherapeutics/diga/model/DigaInvoiceResponseError.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaInvoiceResponseError.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class DigaInvoiceResponseError implements DigaApiResponseError {
-  /** The ID of the validation step that errored */
+  /** The ID of the validation step that errored. May be null if no scenario was matched. */
   private final String validationStepId;
   /** The messages received for the error in the report */
   private final String messages;

--- a/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReaderTest.java
+++ b/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReaderTest.java
@@ -18,11 +18,18 @@
 
 package com.alextherapeutics.diga.implementation;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.alextherapeutics.diga.DigaXmlReaderException;
+import com.alextherapeutics.diga.model.generatedxml.billingreport.Report;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -303,5 +310,51 @@ class DigaXmlJaxbRequestReaderTest {
         reader.readCodeValidationResponse(
             new ByteArrayInputStream(sampleCodeValidationAnswer.getBytes(StandardCharsets.UTF_8)));
     Assertions.assertNotNull(response);
+  }
+
+  @Test
+  void testCanHandleNoScenarioMatchedReport()
+      throws NoSuchFieldException, IllegalAccessException, JAXBException, DigaXmlReaderException {
+    var unMarshallerMock = mock(Unmarshaller.class);
+    // some ugly reflection here due to JAXB instantiation structure, mocking is complicated
+    var unmarshallerField = reader.getClass().getDeclaredField("billingReportUnmarshaller");
+    unmarshallerField.setAccessible(true);
+    unmarshallerField.set(reader, unMarshallerMock);
+
+    var report = new Report();
+    report.setValid(false);
+    report.setScenarioMatched(null);
+    var noScenarioMatched = new Report.NoScenarioMatched();
+    report.setNoScenarioMatched(noScenarioMatched);
+
+    when(unMarshallerMock.unmarshal(any(ByteArrayInputStream.class))).thenReturn(report);
+
+    var result = reader.readBillingReport(new ByteArrayInputStream("".getBytes()));
+    assertTrue(result.isHasError());
+    var errors = result.getErrors();
+    assertEquals(1, errors.size());
+    assertNotNull(errors.get(0).asInvoiceResponseError().getMessages());
+    assertFalse(errors.get(0).asInvoiceResponseError().getMessages().isEmpty());
+  }
+
+  @Test
+  void testCanHandleNullValuesInReport()
+      throws NoSuchFieldException, IllegalAccessException, JAXBException, DigaXmlReaderException {
+    var unMarshallerMock = mock(Unmarshaller.class);
+    // some ugly reflection here due to JAXB instantiation structure, mocking is complicated
+    var unmarshallerField = reader.getClass().getDeclaredField("billingReportUnmarshaller");
+    unmarshallerField.setAccessible(true);
+    unmarshallerField.set(reader, unMarshallerMock);
+
+    var report = new Report();
+    report.setValid(false);
+    when(unMarshallerMock.unmarshal(any(ByteArrayInputStream.class))).thenReturn(report);
+
+    var result = reader.readBillingReport(new ByteArrayInputStream("".getBytes()));
+    assertTrue(result.isHasError());
+    var errors = result.getErrors();
+    assertEquals(1, errors.size());
+    assertNotNull(errors.get(0).asInvoiceResponseError().getMessages());
+    assertFalse(errors.get(0).asInvoiceResponseError().getMessages().isEmpty());
   }
 }


### PR DESCRIPTION
# Pull Request

### Description
<!-- describe your pull request -->
the null pointer appeared because the validator returned "noScenarioMatched", and null in "scenarioMatched"

- handle generating proper error responses when no scenario was matched
- run mvn spotless:apply which did some linting on your fixes

this works for me without null pointers, please check that your request still works for TK

### Closes
<!-- add references to issues you are closing here -->

